### PR TITLE
perf: include `sizes` attribute in Image components

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 
 Source files for the People's App Slide Deck.
 
+[deck.peoplesapp.org](https://deck.peoplesapp.org)

--- a/src/components/figmaSlideCell.astro
+++ b/src/components/figmaSlideCell.astro
@@ -80,6 +80,7 @@ if (preloadBackground) {
           src={obj.img}
           width={obj.width}
           widths={[obj.width, obj.width * 2]}
+          sizes={`${obj.width}px`}
           alt='Slide Object'
           data-id={obj.dataId}
           loading={preloadBackground ? 'eager' : 'lazy'}


### PR DESCRIPTION
**Context**: **Slide Objects** are passed to the `figmaSlideCell` component as an array of objects that is mapped over the displayed on the screen at the given size and coordinates. We have doubled the **Slide Object** images by exporting them at 2x then down-sizing them to half their intrinsic width for responsive loading. These images are meant to load at 2x on Retina displays and 1x on non-Retina displays. The images are currently loading at 2x regardless of the display used.

**Action**: Include a `sizes` attribute in the Astro `<Image>` component with a value of the width passed through the Slide Objects properties.

**Result**: Slide Object images are loaded at 1x on normal screens and 2x on Retina devices. The Astro widths array is functioning as intended with the `sizes` property unlocking responsive performance functionality.

 #24